### PR TITLE
Grist: Raise proxy-body-size

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.2.7
+version: 5.2.8

--- a/charts/grist/README.md
+++ b/charts/grist/README.md
@@ -9,29 +9,30 @@ helm repo update
 
 ### General configuration
 
-| Name                                  | Description                                              | Value             |
-| ------------------------------------- | -------------------------------------------------------- | ----------------- |
-| `image.repository`                    | Repository to use to pull Grist's container image        | `gristlabs/grist` |
-| `image.tag`                           | Grist's container tag                                    | `1.1.9`           |
-| `image.pullPolicy`                    | Container image pull policy                              | `IfNotPresent`    |
-| `image.credentials.username`          | Username for container registry authentication           |                   |
-| `image.credentials.password`          | Password for container registry authentication           |                   |
-| `image.credentials.registry`          | Registry url for which the credentials are specified     |                   |
-| `image.credentials.name`              | Name of the generated secret for imagePullSecrets        |                   |
-| `nameOverride`                        | Override the chart name                                  | `""`              |
-| `fullnameOverride`                    | Override the full application name                       | `""`              |
-| `mountFiles[].path`                   | Mount a static file to a specific path on the Grist Pods |                   |
-| `mountFiles[].content`                | File content encoded in base64                           |                   |
-| `ingress.enabled`                     | whether to enable the Ingress or not                     | `false`           |
-| `ingress.className`                   | IngressClass to use for the Ingress                      | `nil`             |
-| `ingress.host`                        | Host for the Ingress                                     | `nil`             |
-| `ingress.path`                        | Path to use for the Ingress                              | `/`               |
-| `ingress.hosts[].host`                | Additionnal host to configure for the Ingress            |                   |
-| `ingress.hosts[].paths[].path`        | Custom paths to configure for the Ingress host           |                   |
-| `ingress.hosts[].paths[].pathType`    | Type for each custom path                                |                   |
-| `ingress.tls.enabled`                 | Wether to enable TLS for the Ingress                     | `true`            |
-| `ingress.tls.additional[].secretName` | Secret name for additional TLS config                    |                   |
-| `ingress.tls.additional[].hosts[]`    | Hosts for additional TLS config                          |                   |
+| Name                                                              | Description                                              | Value                                                    |
+| ----------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| `image.repository`                                                | Repository to use to pull Grist's container image        | `gristlabs/grist`                                        |
+| `image.tag`                                                       | Grist's container tag                                    | `1.1.9`                                                  |
+| `image.pullPolicy`                                                | Container image pull policy                              | `IfNotPresent`                                           |
+| `image.credentials.username`                                      | Username for container registry authentication           |                                                          |
+| `image.credentials.password`                                      | Password for container registry authentication           |                                                          |
+| `image.credentials.registry`                                      | Registry url for which the credentials are specified     |                                                          |
+| `image.credentials.name`                                          | Name of the generated secret for imagePullSecrets        |                                                          |
+| `nameOverride`                                                    | Override the chart name                                  | `""`                                                     |
+| `fullnameOverride`                                                | Override the full application name                       | `""`                                                     |
+| `mountFiles[].path`                                               | Mount a static file to a specific path on the Grist Pods |                                                          |
+| `mountFiles[].content`                                            | File content encoded in base64                           |                                                          |
+| `ingress.enabled`                                                 | whether to enable the Ingress or not                     | `false`                                                  |
+| `ingress.className`                                               | IngressClass to use for the Ingress                      | `nil`                                                    |
+| `ingress.host`                                                    | Host for the Ingress                                     | `nil`                                                    |
+| `ingress.path`                                                    | Path to use for the Ingress                              | `/`                                                      |
+| `ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` | Set the client_max_body_size for Ingress' Nginx          | `{"nginx.ingress.kubernetes.io/proxy-body-size":"500m"}` |
+| `ingress.hosts[].host`                                            | Additionnal host to configure for the Ingress            |                                                          |
+| `ingress.hosts[].paths[].path`                                    | Custom paths to configure for the Ingress host           |                                                          |
+| `ingress.hosts[].paths[].pathType`                                | Type for each custom path                                |                                                          |
+| `ingress.tls.enabled`                                             | Wether to enable TLS for the Ingress                     | `true`                                                   |
+| `ingress.tls.additional[].secretName`                             | Secret name for additional TLS config                    |                                                          |
+| `ingress.tls.additional[].hosts[]`                                | Hosts for additional TLS config                          |                                                          |
 
 ### Home worker
 

--- a/charts/grist/values.yaml
+++ b/charts/grist/values.yaml
@@ -40,6 +40,9 @@ ingress:
   className: null
   host: null
   path: /
+  annotations:
+    ## @param ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size Set the client_max_body_size for Ingress' Nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 500m
   ## @skip ingress.hosts Additionnal host to configure for the Ingress
   ## @extra ingress.hosts[].host Additionnal host to configure for the Ingress
   ## @extra ingress.hosts[].paths[].path Custom paths to configure for the Ingress host


### PR DESCRIPTION
## Contexte

Fixes #15 

Lors d'un import de fichier sur Grist de plus d'1Mo, on a une erreur 413.

## Solution proposée

On ajoute l'annotation suivante pour permettre d'augmenter le client_max_body_size côté Nginx :
https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size