### PR TITLE
[Grist] tweak the values for allowing debugging containers

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.2.9
+version: 5.3.0

--- a/charts/grist/examples/helmfile/values.grist.yaml
+++ b/charts/grist/examples/helmfile/values.grist.yaml
@@ -1,6 +1,8 @@
+# Documentation for Grist variables is available here: https://github.com/gristlabs/grist-core
 commonEnvVars: &commonEnvVars
   APP_HOME_URL: https://grist.127.0.0.1.nip.io
   GRIST_ORG_IN_PATH: "true"
+  # For OIDC, see this documentation: https://support.getgrist.com/install/oidc/
   GRIST_OIDC_SP_HOST: https://grist.127.0.0.1.nip.io/
   GRIST_OIDC_IDP_ISSUER: http://keycloak.grist.svc.cluster.local/realms/grist
   GRIST_OIDC_IDP_SCOPES: openid email organizations
@@ -22,10 +24,16 @@ commonEnvVars: &commonEnvVars
   TYPEORM_PASSWORD: grist
   GRIST_SINGLE_PORT: 0
   GRIST_ALLOWED_HOSTS: grist.127.0.0.1.nip.io
+  GRIST_BOOT_KEY: bootkey
+  GRIST_LOG_SKIP_HTTP: false
+  NODE_OPTIONS: '--inspect --enable-source-maps' # This enables the debugger in the containers
+  GRIST_MAX_UPLOAD_IMPORT_MB: 300
 
 
 docWorker:
-  replicas: 2
+  replicas: 1
+  probes:
+    liveness: null # Disable the liveness probe for allowing debugging the NodeJS process
   envVars:
     <<: *commonEnvVars
 
@@ -39,7 +47,9 @@ docWorker:
     GRIST_DOCS_MINIO_SECRET_KEY: gristgristgrist
 
 homeWorker:
-  replicas: 2
+  replicas: 1
+  probes:
+    liveness: null # Disable the liveness probe for allowing debugging the NodeJS process
   envVars:
     <<: *commonEnvVars
 

--- a/charts/grist/examples/helmfile/values.grist.yaml
+++ b/charts/grist/examples/helmfile/values.grist.yaml
@@ -25,7 +25,7 @@ commonEnvVars: &commonEnvVars
   GRIST_SINGLE_PORT: 0
   GRIST_ALLOWED_HOSTS: grist.127.0.0.1.nip.io
   GRIST_BOOT_KEY: bootkey
-  GRIST_LOG_SKIP_HTTP: false
+  GRIST_LOG_SKIP_HTTP: ''
   NODE_OPTIONS: '--inspect --enable-source-maps' # This enables the debugger in the containers
   GRIST_MAX_UPLOAD_IMPORT_MB: 300
 


### PR DESCRIPTION
Several improvements in the default variables (assuming it won't be used as is in production):
 - add the `GRIST_BOOT_KEY` to allow diagnosing the instance;
 - `GRIST_LOG_SKIP_HTTP` to allow logging requests
 - Run the nodejs in debug mode by default to allow debugging through the nodejs devtools;
 - Disable the liveness probe which stops the container when debugging step by step;

See #19 (but it does not solve entirely, the documentation is still missing)