### PR TITLE
Grist: Use mc backup

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.3.0
+version: 5.3.1

--- a/charts/grist/examples/backup/Dockerfile
+++ b/charts/grist/examples/backup/Dockerfile
@@ -2,12 +2,9 @@ FROM alpine:3.12
 
 RUN apk --no-cache add \
     bash \
-    py3-pip \
     pigz \
     tar
-RUN pip3 install --no-cache-dir \
-    awscli \
-    awscli-plugin-endpoint
+COPY --from=minio/mc:RELEASE.2024-03-13T23-51-57Z /bin/mc /bin/mc
 
 COPY ./backup.sh /usr/local/bin/backup.sh
 RUN chmod +x /usr/local/bin/backup.sh


### PR DESCRIPTION
A commit from vigigloo is missing : `feat: use mc instead of aws cli as it has better multipart handling` ([link to the original commit](https://gitlab.com/vigigloo/tools/grist/-/commit/a61a5e4ac365618cadf6d69609c77b7facde8763))