### PR TITLE
Grist: Add APP_HOME_INTERNAL_URL

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.3.3
+version: 5.3.4
 appVersion: 1.1.13

--- a/charts/grist/examples/helmfile/values.grist.yaml
+++ b/charts/grist/examples/helmfile/values.grist.yaml
@@ -1,6 +1,7 @@
 # Documentation for Grist variables is available here: https://github.com/gristlabs/grist-core
 commonEnvVars: &commonEnvVars
   APP_HOME_URL: https://grist.127.0.0.1.nip.io
+  APP_HOME_INTERNAL_URL: http://grist-home-wk
   GRIST_ORG_IN_PATH: "true"
   # For OIDC, see this documentation: https://support.getgrist.com/install/oidc/
   GRIST_OIDC_SP_HOST: https://grist.127.0.0.1.nip.io/


### PR DESCRIPTION
For Grist.

Adds `APP_HOME_INTERNAL_URL` env variable introduced in version 1.1.14. Quoting the upstream README:

> like APP_HOME_URL but used by the home and the doc servers to reach any home workers using an internal domain name resolution (like in a docker environment). Defaults to APP_HOME_URL

Fixes:
- Impossible to open templates and tutorials right after having converted them;
- Impossible to submit forms since version 1.1.13;
- Impossible to restore a previous version of a document (snapshot);
- Impossible to copy a document;

Depends on #37 