### PR TITLE
[GRIST] Fix template when using hosts

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.3.7
+version: 5.3.8
 appVersion: 1.1.17

--- a/charts/grist/templates/ingress.yaml
+++ b/charts/grist/templates/ingress.yaml
@@ -90,11 +90,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "grist.lb.fullname" . }}
+                name: {{ include "grist.lb.fullname" $ }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ include "grist.lb.fullname" . }}
+              serviceName: {{ include "grist.lb.fullname" $ }}
               servicePort: {{ $svcPort }}
             {{- end }}
           {{- range .paths }}
@@ -105,11 +105,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "grist.home.fullname" . }}
+                name: {{ include "grist.home.fullname" $ }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ include "grist.home.fullname" . }}
+              serviceName: {{ include "grist.home.fullname" $ }}
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
Because the includes are within a range context, they need to be passed $ instead of . to get the release name and other info