### PR TITLE
feat(sites-faciles): add sites-faciles helm chart

### DIFF
--- a/charts/sites-faciles/.gitignore
+++ b/charts/sites-faciles/.gitignore
@@ -1,0 +1,9 @@
+# Created by https://www.toptal.com/developers/gitignore/api/helm
+# Edit at https://www.toptal.com/developers/gitignore?templates=helm
+
+### Helm ###
+# Chart dependencies
+**/charts/*.tgz
+
+# End of https://www.toptal.com/developers/gitignore/api/helm
+

--- a/charts/sites-faciles/Chart.lock
+++ b/charts/sites-faciles/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgres
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.16.0
+digest: sha256:98f8133bc4dcfc0bbf731ce08331f788d31a1a31351f90659f4ce2051fef36e5
+generated: "2026-02-17T18:37:47.584933+01:00"

--- a/charts/sites-faciles/Chart.yaml
+++ b/charts/sites-faciles/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: sites-faciles
+type: application
+version: 0.1.0
+appVersion: "2.5.2"
+description: A Helm chart to deploy sites-faciles.
+home: https://sites.beta.gouv.fr
+deprecated: false
+annotations: {}
+keywords: []
+dependencies:
+- name: postgres
+  alias: postgresql
+  version: "0.16.0"
+  repository: oci://registry-1.docker.io/cloudpirates
+  condition: postgresql.enabled
+sources:
+- https://github.com/numerique-gouv/sites-faciles
+- https://github.com/numerique-gouv/helm-charts
+maintainers: []

--- a/charts/sites-faciles/README.md
+++ b/charts/sites-faciles/README.md
@@ -1,0 +1,236 @@
+# sites-faciles
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.2](https://img.shields.io/badge/AppVersion-2.5.2-informational?style=flat-square)
+
+A Helm chart to deploy sites-faciles.
+
+**Homepage:** <https://sites.beta.gouv.fr>
+
+## Source Code
+
+* <https://github.com/numerique-gouv/sites-faciles>
+* <https://github.com/numerique-gouv/helm-charts>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| oci://registry-1.docker.io/cloudpirates | postgresql(postgres) | 0.16.0 |
+
+## Values
+
+### General
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration. |
+| args | list | `[]` | Container command args. |
+| command | list | `[]` | Container command. |
+| containerPort | int | `8000` | Container port. |
+| env | object | `{}` | Container env variables, it will be injected into a configmap and loaded into the container. |
+| envFrom | list | `[]` | Container env variables loaded from configmap or secret reference. |
+| extraContainers | list | `[]` | Extra containers to add to the pod as sidecars. |
+| extraObjects | list | `[]` | Add extra specs dynamically to this chart. |
+| extraPorts | list | `[]` | Extra container ports. |
+| fullnameOverride | string | `""` | String to fully override the default application name. |
+| hostAliases | list | `[]` | Host aliases that will be injected at pod-level into /etc/hosts. |
+| initContainers | list | `[]` | Init containers to add to the pod. |
+| nameOverride | string | `""` | Provide a name in place of the default application name. |
+| nodeSelector | object | `{}` | Default node selector. |
+| pdb.annotations | object | `{}` | Annotations to be added to pdb. |
+| pdb.enabled | bool | `false` | Deploy a PodDisruptionBudget |
+| pdb.labels | object | `{}` | Labels to be added to pdb. |
+| pdb.maxUnavailable | string | `""` | Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). Has higher precedence over `pdb.minAvailable`. |
+| pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%). |
+| podAnnotations | object | `{}` | Annotations for the deployed pods. |
+| podLabels | object | `{}` | Labels for the deployed pods. |
+| podSecurityContext | object | `{}` | Toggle and define pod-level security context. |
+| replicaCount | int | `1` | The number of application controller pods to run. |
+| revisionHistoryLimit | int | `10` | Revision history limit. |
+| secrets | object | `{}` | Container env secrets, it will be injected into a secret and loaded into the container. |
+| securityContext | object | `{}` | Toggle and define container-level security context. |
+| strategy.rollingUpdate.maxSurge | int | `1` | The maximum number of pods that can be scheduled above the desired number of pods. |
+| strategy.rollingUpdate.maxUnavailable | int | `1` | The maximum number of pods that can be unavailable during the update process. |
+| strategy.type | string | `"RollingUpdate"` | Strategy type used to replace old Pods by new ones, can be `Recreate` or `RollingUpdate`. |
+| tolerations | list | `[]` | Default tolerations. |
+
+### Autoscaling
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler. |
+| autoscaling.maxReplicas | int | `3` | Maximum number of replicas. |
+| autoscaling.minReplicas | int | `1` | Minimum number of replicas. |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Average CPU utilization percentage. |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` | Average memory utilization percentage. |
+
+### Config
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| config.allowedHosts | string | `"localhost,127.0.0.1"` | The domain(s) authorized to access the site, separated by commas if more than one. |
+| config.defaultFromEmail | string | `"no-reply@domain.local"` | Default email address used for sending emails. |
+| config.djangoSuperuserEmail | string | `""` | Django superuser email (Default to `<djangoSuperuserUsername>@domain.local` if not set). |
+| config.djangoSuperuserPassword | string | `""` | Django superuser password (Default to autogenerating a random password if not set). |
+| config.djangoSuperuserUsername | string | `""` | Django superuser username (Default to `admin` if not set). |
+| config.emailHost | string | `""` | Host to use for sending emails. |
+| config.emailHostPassword | string | `""` | Password to use for the SMTP server defined in `EMAIL_HOST`. |
+| config.emailHostUser | string | `""` | Username to use for the SMTP server defined in `EMAIL_HOST`. |
+| config.emailPort | int | `465` | Port to use for the SMTP server defined above. |
+| config.emailSslCertfile | string | `""` | If `EMAIL_USE_SSL` or `EMAIL_USE_TLS` are true, optionally set the path to a PEM certificate chain file for SSL connection. |
+| config.emailSslKeyfile | string | `""` | If `EMAIL_USE_SSL` or `EMAIL_USE_TLS` are true, optionally set the path to a PEM private key file for SSL connection. |
+| config.emailTimeout | int | `30` | Timeout in seconds for blocking operations such as connection attempts. Must not be zero. |
+| config.emailUseSsl | bool | `false` | Whether to use implicit TLS (SSL) for SMTP communication. |
+| config.emailUseTls | bool | `true` | Whether to use a secure TLS connection for SMTP communication. |
+| config.hostProto | string | `"http"` | The protocol to use for the app's main URL. |
+| config.hostUrl | string | `"localhost:8000"` | The domain name of your site's main URL. |
+| config.s3BucketName | string | `""` | Name of the S3 bucket to use for storage. |
+| config.s3BucketRegion | string | `""` | AWS region of the S3 bucket. |
+| config.s3Host | string | `""` | S3 host (without https://), e.g. `s3.amazonaws.com`. |
+| config.s3KeyId | string | `""` | S3 access key ID for authentication. |
+| config.s3KeySecret | string | `""` | S3 secret access key for authentication. |
+| config.s3Location | string | `""` | The S3_LOCATION parameter is optional, but allows you to share the S3 bucket with several Easy Sites installations. We recommend using the app name as the value. |
+| config.secretKey | string | `""` | Secret key, for example generated in a terminal with the command `openssl rand -hex 32` (Default to a random value if not set). |
+| config.wagtailPasswordResetEnabled | bool | `true` | Allow users to request a password reset. |
+
+### Image
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the app. |
+| image.repository | string | `"ghcr.io/numerique-gouv/sites-faciles"` | Repository to use for the app. |
+| image.tag | string | `""` | Tag to use for the app. Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | Image credentials configuration. |
+
+### Ingress
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| ingress.annotations | object | `{}` | Additional ingress annotations. |
+| ingress.className | string | `""` | Defines which ingress controller will implement the resource. |
+| ingress.enabled | bool | `false` | Whether or not ingress should be enabled. |
+| ingress.hosts[0].backend.portNumber | string | `nil` | Port used by the backend service linked to the host record (leave null to use the app service port). |
+| ingress.hosts[0].backend.serviceName | string | `""` | Name of the backend service linked to the host record (leave empty to use the app service). |
+| ingress.hosts[0].name | string | `"domain.local"` | Name of the host record. |
+| ingress.hosts[0].path | string | `"/"` | Path of the host record to manage routing. |
+| ingress.hosts[0].pathType | string | `"Prefix"` | Path type of the host record. |
+| ingress.labels | object | `{}` | Additional ingress labels. |
+| ingress.tls | list | `[]` | Enable TLS configuration. |
+
+### Metrics
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| metrics.enabled | bool | `false` | Deploy metrics service. |
+| metrics.service.annotations | object | `{}` | Metrics service annotations. |
+| metrics.service.labels | object | `{}` | Metrics service labels. |
+| metrics.service.port | int | `9100` | Metrics service port. |
+| metrics.service.targetPort | int | `9100` | Metrics service target port. |
+| metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations. |
+| metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor. |
+| metrics.serviceMonitor.endpoints[0].basicAuth.password | string | `""` | The secret in the service monitor namespace that contains the password for authentication. |
+| metrics.serviceMonitor.endpoints[0].basicAuth.username | string | `""` | The secret in the service monitor namespace that contains the username for authentication. |
+| metrics.serviceMonitor.endpoints[0].bearerTokenSecret.key | string | `""` | Secret key to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator. |
+| metrics.serviceMonitor.endpoints[0].bearerTokenSecret.name | string | `""` | Secret name to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator. |
+| metrics.serviceMonitor.endpoints[0].honorLabels | bool | `false` | When true, honorLabels preserves the metric's labels when they collide with the target's labels. |
+| metrics.serviceMonitor.endpoints[0].interval | string | `"30s"` | Prometheus ServiceMonitor interval. |
+| metrics.serviceMonitor.endpoints[0].metricRelabelings | list | `[]` | Prometheus MetricRelabelConfigs to apply to samples before ingestion. |
+| metrics.serviceMonitor.endpoints[0].path | string | `"/metrics"` | Path used by the Prometheus ServiceMonitor to scrape metrics. |
+| metrics.serviceMonitor.endpoints[0].relabelings | list | `[]` | Prometheus RelabelConfigs to apply to samples before scraping. |
+| metrics.serviceMonitor.endpoints[0].scheme | string | `""` | Prometheus ServiceMonitor scheme. |
+| metrics.serviceMonitor.endpoints[0].scrapeTimeout | string | `"10s"` | Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used. |
+| metrics.serviceMonitor.endpoints[0].selector | object | `{}` | Prometheus ServiceMonitor selector. |
+| metrics.serviceMonitor.endpoints[0].tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig. |
+| metrics.serviceMonitor.labels | object | `{}` | Prometheus ServiceMonitor labels. |
+
+### NetworkPolicy
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| networkPolicy.create | bool | `false` | Create NetworkPolicy object. |
+| networkPolicy.egress | list | `[]` | Egress rules for the NetworkPolicy object. |
+| networkPolicy.ingress | list | `[]` | Ingress rules for the NetworkPolicy object. |
+| networkPolicy.policyTypes | list | `["Ingress"]` | Policy types used in the NetworkPolicy object. |
+
+### Database
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| postgresql.auth.database | string | `"sitesfaciles"` | Name of the database to create. |
+| postgresql.auth.existingSecret | string | `""` | Name of an existing secret containing PostgreSQL credentials. |
+| postgresql.auth.password | string | `""` | PostgreSQL admin password (auto-generated if not set). |
+| postgresql.auth.username | string | `"sitesfaciles"` | PostgreSQL admin username (also creates a database with the same name). |
+| postgresql.enabled | bool | `true` | Enable the PostgreSQL subchart (See. https://artifacthub.io/packages/helm/cloudpirates-postgres/postgres). |
+| postgresql.fullnameOverride | string | `"sites-faciles-postgresql"` | Override the fullname of the PostgreSQL subchart. |
+| postgresql.persistence.enabled | bool | `true` | Enable persistence using PVC. |
+| postgresql.persistence.size | string | `"1Gi"` | Size of the PVC for PostgreSQL data. |
+| postgresql.resources.limits.cpu | string | `"200m"` | CPU limit for PostgreSQL. |
+| postgresql.resources.limits.memory | string | `"512Mi"` | Memory limit for PostgreSQL. |
+| postgresql.resources.requests.cpu | string | `"200m"` | CPU request for PostgreSQL. |
+| postgresql.resources.requests.memory | string | `"512Mi"` | Memory request for PostgreSQL. |
+
+### Probes
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| probes.healthcheck.path | string | `"/"` | Container healthcheck endpoint. |
+| probes.healthcheck.port | int | `8000` | Port to use for healthcheck (defaults to container port if not set) |
+| probes.livenessProbe.enabled | bool | `true` | Whether or not enable the probe. |
+| probes.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the probe to be considered failed after having succeeded. |
+| probes.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds after the container has started before probe is initiated. |
+| probes.livenessProbe.periodSeconds | int | `30` | How often (in seconds) to perform the probe. |
+| probes.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed. |
+| probes.livenessProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
+| probes.readinessProbe.enabled | bool | `true` | Whether or not enable the probe. |
+| probes.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the probe to be considered failed after having succeeded. |
+| probes.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before probe is initiated. |
+| probes.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe. |
+| probes.readinessProbe.successThreshold | int | `2` | Minimum consecutive successes for the probe to be considered successful after having failed. |
+| probes.readinessProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
+| probes.startupProbe.enabled | bool | `true` | Whether or not enable the probe. |
+| probes.startupProbe.failureThreshold | int | `10` | Minimum consecutive failures for the probe to be considered failed after having succeeded. |
+| probes.startupProbe.initialDelaySeconds | int | `5` | Number of seconds after the container has started before probe is initiated. |
+| probes.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe. |
+| probes.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed. |
+| probes.startupProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
+
+### Resources
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| resources.limits.cpu | string | `"1"` | CPU limit. |
+| resources.limits.memory | string | `"1Gi"` | Memory limit. |
+| resources.requests.cpu | string | `"200m"` | CPU request. |
+| resources.requests.memory | string | `"256Mi"` | Memory request. |
+
+### Service
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| service.extraPorts | list | `[]` | Extra service ports. |
+| service.nodePort | int | `31000` | Port used when type is `NodePort` to expose the service on the given node port. |
+| service.port | int | `80` | Port used by the service. |
+| service.portName | string | `"http"` | Port name used by the service. |
+| service.protocol | string | `"TCP"` | Protocol used by the service. |
+| service.type | string | `"ClusterIP"` | Type of service to create. |
+
+### Service Account
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| serviceAccount.annotations | object | `{}` | Annotations applied to created service account. |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Should the service account access token be automount in the pod. |
+| serviceAccount.create | bool | `false` | Create a service account. |
+| serviceAccount.enabled | bool | `false` | Enable the service account. |
+| serviceAccount.name | string | `""` | Service account name. |
+
+### Volumes
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| volumeClaims | list | `[]` | List of volumeClaims to add. |
+| volumeMounts | list | `[]` | List of mounts to add (normally used with `volumes` or `volumeClaims`). |
+| volumes | list | `[]` | List of volumes to add. |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/sites-faciles/templates/NOTES.txt
+++ b/charts/sites-faciles/templates/NOTES.txt
@@ -1,0 +1,28 @@
+{{- /* Output connection info for the user */ -}}
+
+{{- $hostProto := .Values.config.hostProto -}}
+{{- $hostUrl := .Values.config.hostUrl -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $containerPort := .Values.containerPort -}}
+
+Your application is now deployed!
+You can access it at: {{ $hostProto }}://{{ $hostUrl }}
+
+---
+IMPORTANT:
+
+{{- if not .Values.config.djangoSuperuserUsername }}
+  The admin username has been auto-generated. To retrieve it, run:
+
+    kubectl get secret {{ printf "%s-%s" (include "helper.fullname" .) "admin" }} -o jsonpath='{.data.DJANGO_SUPERUSER_USERNAME}' | base64 -d
+{{ end }}
+{{ if not .Values.config.djangoSuperuserPassword }}
+  The admin password has been auto-generated. To retrieve it, run:
+
+    kubectl get secret {{ printf "%s-%s" (include "helper.fullname" .) "admin" }} -o jsonpath='{.data.DJANGO_SUPERUSER_PASSWORD}' | base64 -d
+{{ end }}
+{{ if not .Values.ingress.enabled }}
+  Ingress is not enabled. To access your application locally, run:
+
+    kubectl port-forward svc/{{ include "helper.fullname" . }} {{ $containerPort }}:{{ $svcPort }}
+{{ end }}

--- a/charts/sites-faciles/templates/_helpers.tpl
+++ b/charts/sites-faciles/templates/_helpers.tpl
@@ -1,0 +1,165 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helper.name" -}}
+{{- (.Values.nameOverride | default .Chart.Name) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := .Values.nameOverride | default .Chart.Name }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- (printf "%s-%s" .Release.Name $name) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create image pull secret
+*/}}
+{{- define "helper.imagePullSecret" }}
+{{- $registry := .registry -}}
+{{- $username := .username -}}
+{{- $password := .password -}}
+{{- $email := .email -}}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" $registry $username $password $email (printf "%s:%s" $username $password | b64enc) | b64enc }}
+{{- end }}
+
+{{/*
+Create container environment variables from configmap
+*/}}
+{{- define "helper.env" -}}
+{{ range $key, $val := .env }}
+{{ $key }}: {{ tpl (toYaml $val) . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create container environment variables from secret
+*/}}
+{{- define "helper.secret" -}}
+{{ range $key, $val := .secrets }}
+{{ $key }}: {{ tpl (toYaml $val) . | b64enc }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create container environment variables from config values
+*/}}
+{{- define "helper.config" -}}
+- name: CONTAINER_PORT
+  value: "{{ .Values.containerPort }}"
+{{- if .Values.postgresql.enabled }}
+- name: DATABASE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.postgresql.auth.existingSecret | default .Values.postgresql.fullnameOverride | default "sites-faciles-postgresql" }}
+      key: postgres-password
+- name: DATABASE_URL
+  value: {{ printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:5432/%s" .Values.postgresql.auth.username (.Values.postgresql.fullnameOverride | default "sites-faciles-postgresql") (.Values.postgresql.auth.database | default .Values.postgresql.auth.username) | quote }}
+{{- end }}
+{{- if not .Values.config.djangoSuperuserEmail }}
+- name: DJANGO_SUPERUSER_EMAIL
+  valueFrom:
+    secretKeyRef:
+      name: {{ printf "%s-%s" (include "helper.fullname" .) "admin" }}
+      key: DJANGO_SUPERUSER_EMAIL
+{{- end }}
+{{- if not .Values.config.djangoSuperuserUsername }}
+- name: DJANGO_SUPERUSER_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ printf "%s-%s" (include "helper.fullname" .) "admin" }}
+      key: DJANGO_SUPERUSER_USERNAME
+{{- end }}
+{{- if not .Values.config.djangoSuperuserPassword }}
+- name: DJANGO_SUPERUSER_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ printf "%s-%s" (include "helper.fullname" .) "admin" }}
+      key: DJANGO_SUPERUSER_PASSWORD
+{{- end }}
+{{- if not .Values.config.secretKey }}
+- name: SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ printf "%s-%s" (include "helper.fullname" .) "admin" }}
+      key: SECRET_KEY
+{{- end }}
+{{- range $key, $val := .Values.config }}
+{{- if kindIs "map" $val }}
+{{- if $val.valueFrom }}
+- name: {{ $key | snakecase | upper | quote }}
+  {{- if $val.valueFrom.secretKeyRef }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $val.valueFrom.secretKeyRef.name | quote }}
+      key: {{ $val.valueFrom.secretKeyRef.key | quote }}
+  {{- else if $val.valueFrom.configMapKeyRef }}
+  valueFrom:
+    configMapKeyRef:
+      name: {{ $val.valueFrom.configMapKeyRef.name | quote }}
+      key: {{ $val.valueFrom.configMapKeyRef.key | quote }}
+  {{- end }}
+{{- end }}
+{{- else if $val }}
+- name: {{ $key | snakecase | upper | quote }}
+  value: {{ (tpl (toYaml $val) .) | trimPrefix "'" | trimSuffix "'" | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define a file checksum to trigger rollout on configmap of secret change
+*/}}
+{{- define "helper.checksum" -}}
+{{- $ := index . 0 }}
+{{- $path := index . 1 }}
+{{- $resourceType := include (print $.Template.BasePath $path) $ | fromYaml -}}
+{{- if $resourceType -}}
+checksum/{{ $resourceType.kind | lower }}-{{ $resourceType.metadata.name }}: {{ $resourceType.data | toYaml | sha256sum }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "helper.commonLabels" -}}
+helm.sh/chart: {{ include "helper.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helper.fullname" . | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/instance: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+App labels
+*/}}
+{{- define "helper.labels" -}}
+{{ include "helper.commonLabels" . }}
+{{ include "helper.selectorLabels" . }}
+{{- end -}}

--- a/charts/sites-faciles/templates/admin-secret.yaml
+++ b/charts/sites-faciles/templates/admin-secret.yaml
@@ -1,0 +1,38 @@
+{{- if or (not .Values.config.djangoSuperuserEmail) (not .Values.config.djangoSuperuserUsername) (not .Values.config.djangoSuperuserPassword) (not .Values.config.secretKey) }}
+{{- $secretName := printf "%s-%s" (include "helper.fullname" .) "admin" }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ $secretName }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+data:
+  {{- if not .Values.config.djangoSuperuserEmail }}
+  {{- if and $existing.data $existing.data.DJANGO_SUPERUSER_EMAIL }}
+  DJANGO_SUPERUSER_EMAIL: {{ $existing.data.DJANGO_SUPERUSER_EMAIL | quote }}
+  {{- else }}
+  DJANGO_SUPERUSER_EMAIL: {{ (printf "%s@domain.local" (.Values.config.djangoSuperuserUsername | default "admin")) | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if not .Values.config.djangoSuperuserUsername }}
+  {{- if and $existing.data $existing.data.DJANGO_SUPERUSER_USERNAME }}
+  DJANGO_SUPERUSER_USERNAME: {{ $existing.data.DJANGO_SUPERUSER_USERNAME | quote }}
+  {{- else }}
+  DJANGO_SUPERUSER_USERNAME: {{ "admin" | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if not .Values.config.djangoSuperuserPassword }}
+  {{- if and $existing.data $existing.data.DJANGO_SUPERUSER_PASSWORD }}
+  DJANGO_SUPERUSER_PASSWORD: {{ $existing.data.DJANGO_SUPERUSER_PASSWORD | quote }}
+  {{- else }}
+  DJANGO_SUPERUSER_PASSWORD: {{ randAlphaNum 16 | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if not .Values.config.secretKey }}
+  {{- if and $existing.data $existing.data.SECRET_KEY }}
+  SECRET_KEY: {{ $existing.data.SECRET_KEY | quote }}
+  {{- else }}
+  SECRET_KEY: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/sites-faciles/templates/configmap.yaml
+++ b/charts/sites-faciles/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.env -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "helper.fullname" . }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+data:
+  {{- if .Values.env -}}
+  {{- include "helper.env" .Values | indent 2 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/sites-faciles/templates/deployment.yaml
+++ b/charts/sites-faciles/templates/deployment.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helper.fullname" . }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 10 }}
+  selector:
+    matchLabels: {{- include "helper.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+  template:
+    metadata:
+      {{- if or .Values.podAnnotations .Values.secrets .Values.env }}
+      annotations:
+        {{- include "helper.checksum" (list $ "/configmap.yaml") | nindent 8 }}
+        {{- include "helper.checksum" (list $ "/secret.yaml") | nindent 8 }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels: {{- include "helper.labels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+      - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "helper.fullname" .) }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- tpl (toYaml .Values.initContainers) . | nindent 6 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.command }}
+        command:
+        {{- range .Values.command }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.args }}
+        args:
+        {{- range .Values.args }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.containerPort }}
+          protocol: TCP
+        {{- if .Values.extraPorts }}
+          {{- toYaml .Values.extraPorts | nindent 8 }}
+        {{- end }}
+        env:
+        {{- (include "helper.config" .) | nindent 8 }}
+        {{- if or .Values.env .Values.secrets .Values.envFrom }}
+        envFrom:
+        {{- if .Values.env }}
+        - configMapRef:
+            name: {{ include "helper.fullname" . }}
+        {{- end }}
+        {{- if .Values.secrets }}
+        - secretRef:
+            name: {{ include "helper.fullname" . }}
+        {{- end }}
+        {{- if .Values.envFrom }}
+          {{- toYaml .Values.envFrom | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.probes.healthcheck.path }}
+            port: {{ .Values.probes.healthcheck.port | default .Values.containerPort }}
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.config.hostUrl | default "localhost" }}
+          initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+          successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probes.healthcheck.path }}
+            port: {{ .Values.probes.healthcheck.port | default .Values.containerPort }}
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.config.hostUrl | default "localhost" }}
+          initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+          successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+          periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.probes.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.probes.healthcheck.path }}
+            port: {{ .Values.probes.healthcheck.port | default .Values.containerPort }}
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.config.hostUrl | default "localhost" }}
+          initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+          successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+          periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+        {{- end }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- if .Values.volumeMounts }}
+        volumeMounts: {{- toYaml .Values.volumeMounts | nindent 8 }}
+        {{- end }}
+      {{- if .Values.extraContainers }}
+        {{- tpl (toYaml .Values.extraContainers) . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- toYaml .Values.hostAliases | nindent 6 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 6 }}
+      {{- end }}
+      {{- if .Values.volumes }}
+      volumes: {{- toYaml .Values.volumes | nindent 6 }}
+      {{- end }}

--- a/charts/sites-faciles/templates/extra-objects.yaml
+++ b/charts/sites-faciles/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (ternary . (toYaml .) (typeIs "string" .)) $ }}
+{{ end }}

--- a/charts/sites-faciles/templates/hpa.yaml
+++ b/charts/sites-faciles/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "helper.fullname" . }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "helper.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/sites-faciles/templates/ingress.yaml
+++ b/charts/sites-faciles/templates/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "helper.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+  {{- if .Values.ingress.labels }}
+    {{- toYaml .Values.ingress.labels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- tpl (toYaml .Values.ingress.annotations) . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if gt (len .Values.ingress.tls) 0 }}
+  tls:
+  {{- range .Values.ingress.tls }}
+  - hosts:
+    {{- range .hosts }}
+    - {{ . | quote }}
+    {{- end }}
+    secretName: {{ .secretName | quote | default (printf "%s-%s" $fullName "tls") }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  - host: {{ .name | quote }}
+    http:
+      paths:
+      - path: {{ .path | default "/" }}
+        pathType: {{ .pathType | default "Prefix" }}
+        backend:
+          service:
+          {{- if .backend }}
+            name: {{ .backend.serviceName | default $fullName }}
+            port:
+              number: {{ .backend.portNumber | default $svcPort }}
+          {{- else }}
+            name: {{ $fullName }}
+            port:
+              number: 80
+          {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/sites-faciles/templates/networkpolicy.yaml
+++ b/charts/sites-faciles/templates/networkpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.networkPolicy.create }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "helper.fullname" . }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{- include "helper.selectorLabels" . | nindent 6 }}
+  policyTypes: {{- toYaml .Values.networkPolicy.policyTypes | nindent 2 }}
+  {{- with .Values.networkPolicy.ingress }}
+  ingress: {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress: {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/sites-faciles/templates/pdb.yaml
+++ b/charts/sites-faciles/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "helper.fullname" . }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+  {{- if .Values.pdb.labels }}
+    {{- toYaml .Values.pdb.labels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.pdb.annotations }}
+  annotations: {{- toYaml .Values.pdb.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable | default 0 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "helper.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/sites-faciles/templates/pullsecret.yml
+++ b/charts/sites-faciles/templates/pullsecret.yml
@@ -1,0 +1,12 @@
+{{- range .Values.imagePullSecrets }}
+{{- if and .create .username .password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name | default (printf "%s-%s" (include "helper.fullname" $) "pullsecret") }}
+  labels: {{- include "helper.labels" $ | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "helper.imagePullSecret" dict "username" .username "password" .password "email" .email "registry" .registry }}
+{{- end }}
+{{- end }}

--- a/charts/sites-faciles/templates/secret.yaml
+++ b/charts/sites-faciles/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.secrets -}}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "helper.fullname" . }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+data:
+  {{- if .Values.secrets -}}
+  {{- include "helper.secret" .Values | indent 2 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/sites-faciles/templates/service.yaml
+++ b/charts/sites-faciles/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helper.fullname" . }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: {{ .Values.containerPort }}
+    protocol: {{ .Values.service.protocol | default "TCP" }}
+    {{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+    name: {{ .Values.service.portName | default "http" }}
+  {{- if .Values.service.extraPorts -}}
+  {{- toYaml .Values.service.extraPorts | nindent 2 -}}
+  {{- end }}
+  selector: {{- include "helper.selectorLabels" . | nindent 4 }}

--- a/charts/sites-faciles/templates/serviceaccount.yaml
+++ b/charts/sites-faciles/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.serviceAccount.enabled .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "helper.fullname" .) }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- tpl (toYaml .Values.serviceAccount.annotations) . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/sites-faciles/templates/superuser-job.yaml
+++ b/charts/sites-faciles/templates/superuser-job.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-%s" (include "helper.fullname" .) "superuser" }}
+  labels: {{- include "helper.labels" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+      - name: {{ .name }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "helper.fullname" .) }}
+      {{- end }}
+      restartPolicy: OnFailure
+      containers:
+      - name: superuser
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        {{- (include "helper.config" .) | nindent 8 }}
+        {{- if or .Values.env .Values.secrets .Values.envFrom }}
+        envFrom:
+        {{- if .Values.env }}
+        - configMapRef:
+            name: {{ include "helper.fullname" . }}
+        {{- end }}
+        {{- if .Values.secrets }}
+        - secretRef:
+            name: {{ include "helper.fullname" . }}
+        {{- end }}
+        {{- if .Values.envFrom }}
+          {{- toYaml .Values.envFrom | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for app server to be ready..."
+          export SERVER_HOST={{ include "helper.fullname" . }}
+          export SERVER_PORT={{ .Values.service.port }}
+          until python -c "import socket; s=socket.socket(); s.connect(('$SERVER_HOST', $SERVER_PORT)); s.close()" 2>/dev/null; do
+            echo "App server not ready, waiting..."
+            sleep 5
+          done
+          echo "App server is ready"
+          echo "Checking if superuser needs to be created..."
+          if python manage.py shell -c 'from django.contrib.auth import get_user_model; import sys; sys.exit(0) if get_user_model().objects.filter(is_superuser=True).exists() else sys.exit(1)' 2>/dev/null; then
+            echo "Superuser already exists, skipping creation."
+          else
+            echo "Creating superuser..."
+            python manage.py createsuperuser --noinput
+          fi

--- a/charts/sites-faciles/values.yaml
+++ b/charts/sites-faciles/values.yaml
@@ -1,0 +1,735 @@
+# -- Provide a name in place of the default application name.
+# @section -- General
+nameOverride: ""
+
+# -- String to fully override the default application name.
+# @section -- General
+fullnameOverride: ""
+
+# -- The number of application controller pods to run.
+# @section -- General
+replicaCount: 1
+
+image:
+  # -- Repository to use for the app.
+  # @section -- Image
+  repository: "ghcr.io/numerique-gouv/sites-faciles"
+  # -- Image pull policy for the app.
+  # @section -- Image
+  pullPolicy: "IfNotPresent"
+  # -- Tag to use for the app.
+  # @section -- Image
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+ingress:
+  # -- Whether or not ingress should be enabled.
+  # @section -- Ingress
+  enabled: false
+  # -- Defines which ingress controller will implement the resource.
+  # @section -- Ingress
+  className: ""
+  # -- Additional ingress annotations.
+  # @section -- Ingress
+  annotations: {}
+  # -- Additional ingress labels.
+  # @section -- Ingress
+  labels: {}
+  hosts:
+    - backend:
+        # -- Name of the backend service linked to the host record (leave empty to use the app service).
+        # @section -- Ingress
+        serviceName: ""
+        # -- Port used by the backend service linked to the host record (leave null to use the app service port).
+        # @section -- Ingress
+        portNumber: null
+      # -- Name of the host record.
+      # @section -- Ingress
+      name: "domain.local"
+      # -- Path type of the host record.
+      # @section -- Ingress
+      pathType: "Prefix"
+      # -- Path of the host record to manage routing.
+      # @section -- Ingress
+      path: "/"
+  # -- Enable TLS configuration.
+  # @section -- Ingress
+  tls: []
+  # - secretName: domain.local-tls
+  #   hosts:
+  #   - domain.local
+
+# -- Annotations for the deployed pods.
+# @section -- General
+podAnnotations: {}
+
+# -- Labels for the deployed pods.
+# @section -- General
+podLabels: {}
+
+# -- Toggle and define pod-level security context.
+# @section -- General
+podSecurityContext: {}
+# fsGroup: 2000
+
+# -- Init containers to add to the pod.
+# @section -- General
+initContainers: []
+# - name: wait-for-db-ready
+#   image: docker.io/postgres:17
+#   env:
+#   {{- (include "helper.config" .) | nindent 8 }}
+#   command:
+#   - 'sh'
+#   - '-c'
+#   - |
+#     echo "Waiting for database to be ready..."
+#     until python -c "import os, psycopg2; psycopg2.connect(os.environ['DATABASE_URL'])" 2>/dev/null; do
+#       echo "Database not ready, waiting..."
+#       sleep 5
+#     done
+#     echo "Database is ready"
+# - name: wait-for-keycloak
+#   image: docker.io/curlimages/curl:latest
+#   command:
+#   - "/bin/sh"
+#   - "-c"
+#   args:
+#   - "while [ $(curl -sw '%{http_code}' http://webapp.svc.cluster.local -o /dev/null) -ne 200 ]; do sleep 5; echo 'Waiting for the webapp...'; done"
+#   volumeMounts:
+#   - mountPath: /custom-volume
+#     name: custom-volume
+
+# -- Extra containers to add to the pod as sidecars.
+# @section -- General
+extraContainers: []
+# - name: fluentd
+#   image: "fluentd"
+#   volumeMounts:
+#     - mountPath: /my-volume/config
+#       name: config
+
+# -- Container port.
+# @section -- General
+containerPort: 8000
+
+# -- Extra container ports.
+# @section -- General
+extraPorts: []
+# - containerPort: 9090
+#   protocol: "TCP"
+
+# -- Container command.
+# @section -- General
+command: []
+
+# -- Container command args.
+# @section -- General
+args: []
+
+# -- Toggle and define container-level security context.
+# @section -- General
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# -- Container env variables loaded from configmap or secret reference.
+# @section -- General
+envFrom: []
+# - configMapRef:
+#     name: my-config
+# - secretRef:
+#     name: my-secret
+
+## The config section is used to define environment variables for the container.
+## More values than the ones defined here can be added in this section (even if not listed).
+## Each value can be loaded from a direct value, a configmap reference, or a secret reference.
+config:
+  # -- Django superuser username (Default to `admin` if not set).
+  # @section -- Config
+  djangoSuperuserUsername: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "DJANGO_SUPERUSER_USERNAME"
+  # -- Django superuser password (Default to autogenerating a random password if not set).
+  # @section -- Config
+  djangoSuperuserPassword: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "DJANGO_SUPERUSER_PASSWORD"
+  # -- Django superuser email (Default to `<djangoSuperuserUsername>@domain.local` if not set).
+  # @section -- Config
+  djangoSuperuserEmail: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "DJANGO_SUPERUSER_EMAIL"
+  # -- Secret key, for example generated in a terminal with the command `openssl rand -hex 32` (Default to a random value if not set).
+  # @section -- Config
+  secretKey: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "SECRET_KEY"
+  # -- The protocol to use for the app's main URL.
+  # @section -- Config
+  hostProto: "http"
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "HOST_PROTO"
+  # -- The domain name of your site's main URL.
+  # @section -- Config
+  hostUrl: "localhost:8000"
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "HOST_URL"
+  # -- The domain(s) authorized to access the site, separated by commas if more than one.
+  # @section -- Config
+  allowedHosts: "localhost,127.0.0.1"
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "ALLOWED_HOSTS"
+  # -- Default email address used for sending emails.
+  # @section -- Config
+  defaultFromEmail: "no-reply@domain.local"
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "DEFAULT_FROM_EMAIL"
+  # -- Host to use for sending emails.
+  # @section -- Config
+  emailHost: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_HOST"
+  # -- Port to use for the SMTP server defined above.
+  # @section -- Config
+  emailPort: 465
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_PORT"
+  # -- Username to use for the SMTP server defined in `EMAIL_HOST`.
+  # @section -- Config
+  emailHostUser: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_HOST_USER"
+  # -- Password to use for the SMTP server defined in `EMAIL_HOST`.
+  # @section -- Config
+  emailHostPassword: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_HOST_PASSWORD"
+  # -- Whether to use a secure TLS connection for SMTP communication.
+  # @section -- Config
+  emailUseTls: true
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_USE_TLS"
+  # -- Whether to use implicit TLS (SSL) for SMTP communication.
+  # @section -- Config
+  emailUseSsl: false
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_USE_SSL"
+  # -- Timeout in seconds for blocking operations such as connection attempts. Must not be zero.
+  # @section -- Config
+  emailTimeout: 30
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_TIMEOUT"
+  # -- If `EMAIL_USE_SSL` or `EMAIL_USE_TLS` are true, optionally set the path to a PEM private key file for SSL connection.
+  # @section -- Config
+  emailSslKeyfile: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_SSL_KEYFILE"
+  # -- If `EMAIL_USE_SSL` or `EMAIL_USE_TLS` are true, optionally set the path to a PEM certificate chain file for SSL connection.
+  # @section -- Config
+  emailSslCertfile: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "EMAIL_SSL_CERTFILE"
+  # -- Allow users to request a password reset.
+  # @section -- Config
+  wagtailPasswordResetEnabled: true
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "WAGTAIL_PASSWORD_RESET_ENABLED"
+  # -- Name of the S3 bucket to use for storage.
+  # @section -- Config
+  s3BucketName: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "S3_BUCKET_NAME"
+  # -- AWS region of the S3 bucket.
+  # @section -- Config
+  s3BucketRegion: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "S3_BUCKET_REGION"
+  # -- S3 host (without https://), e.g. `s3.amazonaws.com`.
+  # @section -- Config
+  s3Host: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "S3_HOST"
+  # -- S3 access key ID for authentication.
+  # @section -- Config
+  s3KeyId: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "S3_KEY_ID"
+  # -- S3 secret access key for authentication.
+  # @section -- Config
+  s3KeySecret: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "S3_KEY_SECRET"
+  # -- The S3_LOCATION parameter is optional, but allows you to share the S3 bucket with several Easy Sites installations. We recommend using the app name as the value.
+  # @section -- Config
+  s3Location: ""
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: "sites-faciles-config"
+    #     key: "S3_LOCATION"
+  ## Database URL is automatically generated from the postgresql values but you can override it here.
+  # databaseUrl: ""
+  #   # valueFrom:
+  #   #   secretKeyRef:
+  #   #     name: "sites-faciles-config"
+  #   #     key: "DATABASE_URL"
+
+# -- Container env variables, it will be injected into a configmap and loaded into the container.
+# @section -- General
+env: {}
+
+# -- Container env secrets, it will be injected into a secret and loaded into the container.
+# @section -- General
+secrets: {}
+
+probes:
+  healthcheck:
+    # -- Container healthcheck endpoint.
+    # @section -- Probes
+    path: "/"
+    # -- Port to use for healthcheck (defaults to container port if not set)
+    # @section -- Probes
+    port: 8000
+  startupProbe:
+    # -- Whether or not enable the probe.
+    # @section -- Probes
+    enabled: true
+    # -- Number of seconds after the container has started before probe is initiated.
+    # @section -- Probes
+    initialDelaySeconds: 5
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+    # @section -- Probes
+    successThreshold: 1
+    # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
+    # @section -- Probes
+    failureThreshold: 10
+    # -- How often (in seconds) to perform the probe.
+    # @section -- Probes
+    periodSeconds: 10
+    # -- Number of seconds after which the probe times out.
+    # @section -- Probes
+    timeoutSeconds: 5
+  readinessProbe:
+    # -- Whether or not enable the probe.
+    # @section -- Probes
+    enabled: true
+    # -- Number of seconds after the container has started before probe is initiated.
+    # @section -- Probes
+    initialDelaySeconds: 10
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+    # @section -- Probes
+    successThreshold: 2
+    # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
+    # @section -- Probes
+    failureThreshold: 3
+    # -- How often (in seconds) to perform the probe.
+    # @section -- Probes
+    periodSeconds: 10
+    # -- Number of seconds after which the probe times out.
+    # @section -- Probes
+    timeoutSeconds: 5
+  livenessProbe:
+    # -- Whether or not enable the probe.
+    # @section -- Probes
+    enabled: true
+    # -- Number of seconds after the container has started before probe is initiated.
+    # @section -- Probes
+    initialDelaySeconds: 30
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+    # @section -- Probes
+    successThreshold: 1
+    # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
+    # @section -- Probes
+    failureThreshold: 3
+    # -- How often (in seconds) to perform the probe.
+    # @section -- Probes
+    periodSeconds: 30
+    # -- Number of seconds after which the probe times out.
+    # @section -- Probes
+    timeoutSeconds: 5
+
+strategy:
+  # -- Strategy type used to replace old Pods by new ones, can be `Recreate` or `RollingUpdate`.
+  # @section -- General
+  type: "RollingUpdate"
+  rollingUpdate:
+    # -- The maximum number of pods that can be unavailable during the update process.
+    # @section -- General
+    maxUnavailable: 1
+    # -- The maximum number of pods that can be scheduled above the desired number of pods.
+    # @section -- General
+    maxSurge: 1
+
+# -- Image credentials configuration.
+# @section -- Image
+imagePullSecrets: []
+# - name: "pullsecret-name-1"
+#   create: false
+# - name: "pullsecret-name-2"
+#   create: true
+#   registry: ""
+#   username: ""
+#   password: ""
+#   email: ""
+
+# -- Host aliases that will be injected at pod-level into /etc/hosts.
+# @section -- General
+hostAliases: []
+# - ip: "127.0.0.1"
+#   hostnames:
+#   - "foo.local"
+#   - "bar.local"
+# - ip: "10.1.2.3"
+#   hostnames:
+#   - "foo.remote"
+#   - "bar.remote"
+
+# -- List of volumes to add.
+# @section -- Volumes
+volumes: []
+# - name: medias
+#   emptyDir: {}
+# - name: staticfiles
+#   emptyDir: {}
+
+# -- List of volumeClaims to add.
+# @section -- Volumes
+volumeClaims: []
+# - metadata:
+#     name: app-volume
+#   spec:
+#     accessModes: [ "ReadWriteOnce" ]
+#     storageClassName: "my-storage-class"
+#     resources:
+#       requests:
+#         storage: 1Gi
+
+# -- List of mounts to add (normally used with `volumes` or `volumeClaims`).
+# @section -- Volumes
+volumeMounts: []
+# - name: media
+#   mountPath: /app/medias
+# - name: staticfiles
+#   mountPath: /app/staticfiles
+
+service:
+  # -- Type of service to create.
+  # @section -- Service
+  type: "ClusterIP"
+  # -- Port used by the service.
+  # @section -- Service
+  port: 80
+  # -- Port used when type is `NodePort` to expose the service on the given node port.
+  # @section -- Service
+  nodePort: 31000
+  # -- Port name used by the service.
+  # @section -- Service
+  portName: "http"
+  # -- Protocol used by the service.
+  # @section -- Service
+  protocol: "TCP"
+  # -- Extra service ports.
+  # @section -- Service
+  extraPorts: []
+  # - port: 9090
+  #   targetPort: 9090
+  #   protocol: "TCP" 
+  #   name: "metrics"
+
+resources:
+  requests:
+    # -- Memory request.
+    # @section -- Resources
+    memory: "256Mi"
+    # -- CPU request.
+    # @section -- Resources
+    cpu: "200m"
+  limits:
+    # -- Memory limit.
+    # @section -- Resources
+    memory: "1Gi"
+    # -- CPU limit.
+    # @section -- Resources
+    cpu: "1"
+
+autoscaling:
+  # -- Enable Horizontal Pod Autoscaler.
+  # @section -- Autoscaling
+  enabled: false
+  # -- Minimum number of replicas.
+  # @section -- Autoscaling
+  minReplicas: 1
+  # -- Maximum number of replicas.
+  # @section -- Autoscaling
+  maxReplicas: 3
+  # -- Average CPU utilization percentage.
+  # @section -- Autoscaling
+  targetCPUUtilizationPercentage: 80
+  # -- Average memory utilization percentage.
+  # @section -- Autoscaling
+  targetMemoryUtilizationPercentage: 80
+
+# -- Revision history limit.
+# @section -- General
+revisionHistoryLimit: 10
+
+# -- Default node selector.
+# @section -- General
+nodeSelector: {}
+# kubernetes.io/os: "linux"
+# kubernetes.io/arch: "amd64"
+# kubernetes.io/hostname: "node1"
+
+# -- Default tolerations.
+# @section -- General
+tolerations: []
+# - key: "key1"
+#   operator: "Equal"
+#   value: "value1"
+#   effect: "NoSchedule"
+#   tolerationSeconds: 3600
+
+# -- Affinity configuration.
+# @section -- General
+affinity: {}
+# podAntiAffinity:
+#   requiredDuringSchedulingIgnoredDuringExecution:
+#   - labelSelector:
+#       matchExpressions:
+#       - key: "app.kubernetes.io/name"
+#         operator: "In"
+#         values:
+#         - "sites-faciles"
+#     topologyKey: "kubernetes.io/hostname"
+
+serviceAccount:
+  # -- Enable the service account.
+  # @section -- Service Account
+  enabled: false
+  # -- Create a service account.
+  # @section -- Service Account
+  create: false
+  # -- Annotations applied to created service account.
+  # @section -- Service Account
+  annotations: {}
+  # -- Service account name.
+  # @section -- Service Account
+  name: ""
+  # -- Should the service account access token be automount in the pod.
+  # @section -- Service Account
+  automountServiceAccountToken: false
+
+## Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+pdb:
+  # -- Deploy a PodDisruptionBudget
+  # @section -- General
+  enabled: false
+  # -- Labels to be added to pdb.
+  # @section -- General
+  labels: {}
+  # -- Annotations to be added to pdb.
+  # @section -- General
+  annotations: {}
+  # -- Number of pods that are available after eviction as number or percentage (eg.: 50%).
+  # @section -- General
+  # @default -- `""` (defaults to 0 if not specified)
+  minAvailable: ""
+  # -- Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). Has higher precedence over `pdb.minAvailable`.
+  # @section -- General
+  maxUnavailable: ""
+
+networkPolicy:
+  # -- Create NetworkPolicy object.
+  # @section -- NetworkPolicy
+  create: false
+  # -- Policy types used in the NetworkPolicy object.
+  # @section -- NetworkPolicy
+  policyTypes:
+    - Ingress
+  # -- Ingress rules for the NetworkPolicy object.
+  # @section -- NetworkPolicy
+  ingress: []
+  # -- Egress rules for the NetworkPolicy object.
+  # @section -- NetworkPolicy
+  egress: []
+
+metrics:
+  # -- Deploy metrics service.
+  # @section -- Metrics
+  enabled: false
+  service:
+    # -- Metrics service annotations.
+    # @section -- Metrics
+    annotations: {}
+    # -- Metrics service labels.
+    # @section -- Metrics
+    labels: {}
+    # -- Metrics service port.
+    # @section -- Metrics
+    port: 9100
+    # -- Metrics service target port.
+    # @section -- Metrics
+    targetPort: 9100
+  serviceMonitor:
+    # -- Enable a prometheus ServiceMonitor.
+    # @section -- Metrics
+    enabled: false
+    # -- Prometheus ServiceMonitor labels.
+    # @section -- Metrics
+    labels: {}
+    # -- Prometheus ServiceMonitor annotations.
+    # @section -- Metrics
+    annotations: {}
+    endpoints:
+      - basicAuth:
+          # -- The secret in the service monitor namespace that contains the username for authentication.
+          # @section -- Metrics
+          username: ""
+          # -- The secret in the service monitor namespace that contains the password for authentication.
+          # @section -- Metrics
+          password: ""
+        bearerTokenSecret:
+          # -- Secret name to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator.
+          # @section -- Metrics
+          name: ""
+          # -- Secret key to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator.
+          # @section -- Metrics
+          key: ""
+        # -- Prometheus ServiceMonitor interval.
+        # @section -- Metrics
+        interval: "30s"
+        # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+        # @section -- Metrics
+        scrapeTimeout: "10s"
+        # -- Path used by the Prometheus ServiceMonitor to scrape metrics.
+        # @section -- Metrics
+        path: "/metrics"
+        # -- When true, honorLabels preserves the metric's labels when they collide with the target's labels.
+        # @section -- Metrics
+        honorLabels: false
+        # -- Prometheus RelabelConfigs to apply to samples before scraping.
+        # @section -- Metrics
+        relabelings: []
+        # -- Prometheus MetricRelabelConfigs to apply to samples before ingestion.
+        # @section -- Metrics
+        metricRelabelings: []
+        # -- Prometheus ServiceMonitor selector.
+        # @section -- Metrics
+        selector: {}
+        # prometheus: kube-prometheus
+        # -- Prometheus ServiceMonitor scheme.
+        # @section -- Metrics
+        scheme: ""
+        # -- Prometheus ServiceMonitor tlsConfig.
+        # @section -- Metrics
+        tlsConfig: {}
+
+# -- Add extra specs dynamically to this chart.
+# @section -- General
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: my-configmap
+#   data:
+#     key: {{ .Values.fullname }}
+# - apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: my-secret
+#   type: Opaque
+#   data:
+#     password: {{ "secretpassword" | b64enc | quote }}
+
+postgresql:
+  # -- Enable the PostgreSQL subchart (See. https://artifacthub.io/packages/helm/cloudpirates-postgres/postgres).
+  # @section -- Database
+  enabled: true
+  # -- Override the fullname of the PostgreSQL subchart.
+  # @section -- Database
+  fullnameOverride: "sites-faciles-postgresql"
+  auth:
+    # -- PostgreSQL admin username (also creates a database with the same name).
+    # @section -- Database
+    username: "sitesfaciles"
+    # -- PostgreSQL admin password (auto-generated if not set).
+    # @section -- Database
+    password: ""
+    # -- Name of the database to create.
+    # @section -- Database
+    database: "sitesfaciles"
+    # -- Name of an existing secret containing PostgreSQL credentials.
+    # @section -- Database
+    existingSecret: ""
+  persistence:
+    # -- Enable persistence using PVC.
+    # @section -- Database
+    enabled: true
+    # -- Size of the PVC for PostgreSQL data.
+    # @section -- Database
+    size: 1Gi
+  resources:
+    limits:
+      # -- CPU limit for PostgreSQL.
+      # @section -- Database
+      cpu: 200m
+      # -- Memory limit for PostgreSQL.
+      # @section -- Database
+      memory: 512Mi
+    requests:
+      # -- CPU request for PostgreSQL.
+      # @section -- Database
+      cpu: 200m
+      # -- Memory request for PostgreSQL.
+      # @section -- Database
+      memory: 512Mi


### PR DESCRIPTION
## Description

This PR introduces a new Helm chart for deploying the [sites-faciles](https://github.com/numerique-gouv/sites-faciles) application (Django/Wagtail CMS).

At the moment the [sites-faciles repository](https://github.com/numerique-gouv/sites-faciles) doesn't publish images tagged with the same tag as their releases, I'm in discussion with the project team to evolve the repository CI/CD to publish images during releases (see. https://github.com/numerique-gouv/sites-faciles/pull/374).

## Features

### Database

- Uses the [cloudpirates/postgres](https://artifacthub.io/packages/helm/cloudpirates-postgres/postgres) subchart (`v0.16.0`) for PostgreSQL, enabled by default.
- `DATABASE_URL` is automatically built from the PostgreSQL subchart values.
- The subchart can be disabled (`postgresql.enabled: false`) to use an external database — in that case, set `config.databaseUrl` or provide a `DATABASE_URL` via `envFrom`.

### Config

- All `config.*` values are automatically converted to `SNAKE_CASE` environment variables (e.g., `config.hostUrl` → `HOST_URL`).
- Each config key supports either a raw value or a `valueFrom` reference (`secretKeyRef` / `configMapKeyRef`).
- If `djangoSuperuserUsername`, `djangoSuperuserPassword`, `djangoSuperuserEmail`, or `secretKey` are left empty, they are auto-generated and stored in a `<release>-admin` Secret (preserved across upgrades via `lookup`).
- A post-install Job creates the Django superuser automatically (skips if one already exists).

> **Note:** There is a limitation in ArgoCD with the `lookup` function: https://github.com/argoproj/argo-cd/issues/5202 — auto-generated secrets won't work with ArgoCD. In that case, provide explicit values or use `existingSecret`.

### Probes

- Startup, readiness, and liveness probes are enabled by default.
- HTTP probes send a `Host` header matching `config.hostUrl` to satisfy Django's `ALLOWED_HOSTS` validation.

### Other

- Ingress, HPA, PDB, NetworkPolicy, ServiceAccount — all optional and disabled by default.
- `extraObjects` for deploying arbitrary additional resources.
- Helm NOTES print connection info and commands to retrieve auto-generated credentials.

## Tests

Deploy the chart:

```sh
helm upgrade --install sites-faciles ./charts/sites-faciles
```

> Set `--set postgresql.enabled=false` and provide a `DATABASE_URL` to use an external database instead.

Retrieve superuser credentials:

```sh
echo "Admin username: $(kubectl get secret sites-faciles-admin -o jsonpath='{.data.DJANGO_SUPERUSER_USERNAME}' | base64 -d)"
echo "Admin password: $(kubectl get secret sites-faciles-admin -o jsonpath='{.data.DJANGO_SUPERUSER_PASSWORD}' | base64 -d)"
```

Declare a port-forward:

```sh
kubectl port-forward svc/sites-faciles 8000:80
```

In the browser go to: http://localhost:8000