### PR TITLE
[GRIST]: increase client_max_body_size for internal calls

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.5.3
+version: 5.5.4
 appVersion: 1.6.2

--- a/charts/grist/templates/lb_cm.yaml
+++ b/charts/grist/templates/lb_cm.yaml
@@ -24,6 +24,7 @@ data:
       # Internal url for doc workers, should not be exposed by ingress
       # Used by home worker
       location ~ /internal/dw/([-0-9]*)/(.*)$ {
+        client_max_body_size 50M; # required for attachments in forms
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This fixes a "413: Entity too large" error when submitting forms with attachments whose size is bigger than 1Mb.