### PR TITLE
Fix: grist kind cluster

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.5.5
-appVersion: 1.6.3
+version: 5.5.6
+appVersion: 1.7.4

--- a/charts/grist/examples/helmfile/helmfile.yaml.gotmpl
+++ b/charts/grist/examples/helmfile/helmfile.yaml.gotmpl
@@ -9,6 +9,11 @@ releases:
     chart: bitnami/postgresql
     version: 13.1.5
     values:
+      - image:
+          repository: bitnamilegacy/postgresql
+      - volumePermissions:
+          image:
+            repository: bitnamilegacy/os-shell
       - auth:
           username: grist
           password: grist
@@ -21,6 +26,8 @@ releases:
     chart: bitnami/redis
     version: 18.1.5
     values:
+    - image:
+        repository: bitnamilegacy/redis
     - architecture: standalone
     - auth:
         enabled: true
@@ -31,7 +38,9 @@ releases:
     namespace: grist
     chart: bitnami/minio
     version: 12.10.10
-    values: 
+    values:
+      - image:
+          repository: bitnamilegacy/minio
       - mode: distributed
       - auth:
           rootUser: gristgristgrist
@@ -51,7 +60,11 @@ releases:
     chart: bitnami/keycloak
     version: 17.3.6
     values:
+      - image:
+          repository: bitnamilegacy/keycloak
       - postgresql:
+          image:
+            repository: bitnamilegacy/postgresql
           auth:
             username: keycloak
             password: keycloak

--- a/charts/grist/examples/helmfile/helmfile.yaml.gotmpl
+++ b/charts/grist/examples/helmfile/helmfile.yaml.gotmpl
@@ -68,7 +68,7 @@ releases:
           auth:
             username: keycloak
             password: keycloak
-            databaese: keycloak
+            database: keycloak
       - extraEnvVars:
           - name: KEYCLOAK_EXTRA_ARGS
             value: "--import-realm"

--- a/charts/grist/examples/helmfile/local-cluster.sh
+++ b/charts/grist/examples/helmfile/local-cluster.sh
@@ -90,7 +90,7 @@ data:
 EOF
 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-if ! kubectl -n ingress-nginx get secret mkcert; then
+if ! kubectl -n ingress-nginx get secret mkcert &>/dev/null; then
     kubectl -n ingress-nginx create secret tls mkcert --key 127.0.0.1.nip.io+1-key.pem --cert 127.0.0.1.nip.io+1.pem
 fi
 kubectl -n ingress-nginx patch deployments.apps ingress-nginx-controller --type 'json' -p '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--default-ssl-certificate=ingress-nginx/mkcert"}]'

--- a/charts/grist/examples/helmfile/local-cluster.sh
+++ b/charts/grist/examples/helmfile/local-cluster.sh
@@ -22,6 +22,7 @@ fi
 # https://github.com/kubernetes-sigs/kind/issues/2875
 # https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 # See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
+if ! kind get clusters | grep -q kind; then
 cat <<EOF | kind create cluster --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -31,7 +32,7 @@ containerdConfigPatches:
     config_path = "/etc/containerd/certs.d"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.27.3
+  image: kindest/node:v1.33.4
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -46,10 +47,11 @@ nodes:
     hostPort: 443
     protocol: TCP
 - role: worker
-  image: kindest/node:v1.27.3
+  image: kindest/node:v1.33.4
 - role: worker
-  image: kindest/node:v1.27.3
+  image: kindest/node:v1.33.4
 EOF
+fi
 
 # 3. Add the registry config to the nodes
 #
@@ -88,5 +90,7 @@ data:
 EOF
 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-kubectl -n ingress-nginx create secret tls mkcert --key 127.0.0.1.nip.io+1-key.pem --cert 127.0.0.1.nip.io+1.pem
+if ! kubectl -n ingress-nginx get secret mkcert; then
+    kubectl -n ingress-nginx create secret tls mkcert --key 127.0.0.1.nip.io+1-key.pem --cert 127.0.0.1.nip.io+1.pem
+fi
 kubectl -n ingress-nginx patch deployments.apps ingress-nginx-controller --type 'json' -p '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--default-ssl-certificate=ingress-nginx/mkcert"}]'


### PR DESCRIPTION
This PR fixes grist kind cluster that no longer works.

It's achieved by:
* updating nodes in order to have tls ciphers synced with the ones wanted by current web browsers
* updating docker images sources as bitnami moved it to legacy

We also fix some part of the bootstraping script which cannot be retriggered without failing. 

Thanks @rdeville for the help for fixing bitnami