### PR TITLE
feat(grist): add service account

### DIFF
--- a/charts/grist/Chart.yaml
+++ b/charts/grist/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: grist
-version: 5.5.6
+version: 5.6.0
 appVersion: 1.7.4

--- a/charts/grist/README.md
+++ b/charts/grist/README.md
@@ -1,6 +1,6 @@
 # Grist Helm
 
-```
+```bash
 helm repo add dinum https://numerique-gouv.github.io/helm-charts/
 helm repo update
 ```
@@ -9,30 +9,36 @@ helm repo update
 
 ### General configuration
 
-| Name                                                              | Description                                              | Value                                                    |
-| ----------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
-| `image.repository`                                                | Repository to use to pull Grist's container image        | `gristlabs/grist`                                        |
-| `image.tag`                                                       | Grist's container tag                                    | `1.7.4`                                                  |
-| `image.pullPolicy`                                                | Container image pull policy                              | `IfNotPresent`                                           |
-| `image.credentials.username`                                      | Username for container registry authentication           |                                                          |
-| `image.credentials.password`                                      | Password for container registry authentication           |                                                          |
-| `image.credentials.registry`                                      | Registry url for which the credentials are specified     |                                                          |
-| `image.credentials.name`                                          | Name of the generated secret for imagePullSecrets        |                                                          |
-| `nameOverride`                                                    | Override the chart name                                  | `""`                                                     |
-| `fullnameOverride`                                                | Override the full application name                       | `""`                                                     |
-| `mountFiles[].path`                                               | Mount a static file to a specific path on the Grist Pods |                                                          |
-| `mountFiles[].content`                                            | File content encoded in base64                           |                                                          |
-| `ingress.enabled`                                                 | whether to enable the Ingress or not                     | `false`                                                  |
-| `ingress.className`                                               | IngressClass to use for the Ingress                      | `nil`                                                    |
-| `ingress.host`                                                    | Host for the Ingress                                     | `nil`                                                    |
-| `ingress.path`                                                    | Path to use for the Ingress                              | `/`                                                      |
-| `ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` | Set the client_max_body_size for Ingress' Nginx          | `{"nginx.ingress.kubernetes.io/proxy-body-size":"500m"}` |
-| `ingress.hosts[].host`                                            | Additionnal host to configure for the Ingress            |                                                          |
-| `ingress.hosts[].paths[].path`                                    | Custom paths to configure for the Ingress host           |                                                          |
-| `ingress.hosts[].paths[].pathType`                                | Type for each custom path                                |                                                          |
-| `ingress.tls.enabled`                                             | Wether to enable TLS for the Ingress                     | `true`                                                   |
-| `ingress.tls.additional[].secretName`                             | Secret name for additional TLS config                    |                                                          |
-| `ingress.tls.additional[].hosts[]`                                | Hosts for additional TLS config                          |                                                          |
+| Name                                                              | Description                                                                                 | Value                                                    |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `image.repository`                                                | Repository to use to pull Grist's container image                                           | `gristlabs/grist`                                        |
+| `image.tag`                                                       | Grist's container tag                                                                       | `1.7.4`                                                  |
+| `image.pullPolicy`                                                | Container image pull policy                                                                 | `IfNotPresent`                                           |
+| `image.credentials.username`                                      | Username for container registry authentication                                              |                                                          |
+| `image.credentials.password`                                      | Password for container registry authentication                                              |                                                          |
+| `image.credentials.registry`                                      | Registry url for which the credentials are specified                                        |                                                          |
+| `image.credentials.name`                                          | Name of the generated secret for imagePullSecrets                                           |                                                          |
+| `nameOverride`                                                    | Override the chart name                                                                     | `""`                                                     |
+| `fullnameOverride`                                                | Override the full application name                                                          | `""`                                                     |
+| `mountFiles[].path`                                               | Mount a static file to a specific path on the Grist Pods                                    |                                                          |
+| `mountFiles[].content`                                            | File content encoded in base64                                                              |                                                          |
+| `serviceAccount.enabled`                                          | Whether to enable the service account or not                                                | `false`                                                  |
+| `serviceAccount.name`                                             | Name to use for the service account                                                         | `grist`                                                  |
+| `serviceAccount.imagePullSecrets`                                 | Image pull secrets for the service account                                                  | `[]`                                                     |
+| `serviceAccount.annotations`                                      | Annotations for the service account                                                         | `{}`                                                     |
+| `serviceAccount.labels`                                           | Labels for the service account                                                              | `{}`                                                     |
+| `serviceAccount.automountServiceAccountToken`                     | Set this toggle to false to opt out of automounting API credentials for the service account | `true`                                                   |
+| `ingress.enabled`                                                 | whether to enable the Ingress or not                                                        | `false`                                                  |
+| `ingress.className`                                               | IngressClass to use for the Ingress                                                         | `nil`                                                    |
+| `ingress.host`                                                    | Host for the Ingress                                                                        | `nil`                                                    |
+| `ingress.path`                                                    | Path to use for the Ingress                                                                 | `/`                                                      |
+| `ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size` | Set the client_max_body_size for Ingress' Nginx                                             | `{"nginx.ingress.kubernetes.io/proxy-body-size":"500m"}` |
+| `ingress.hosts[].host`                                            | Additionnal host to configure for the Ingress                                               |                                                          |
+| `ingress.hosts[].paths[].path`                                    | Custom paths to configure for the Ingress host                                              |                                                          |
+| `ingress.hosts[].paths[].pathType`                                | Type for each custom path                                                                   |                                                          |
+| `ingress.tls.enabled`                                             | Wether to enable TLS for the Ingress                                                        | `true`                                                   |
+| `ingress.tls.additional[].secretName`                             | Secret name for additional TLS config                                                       |                                                          |
+| `ingress.tls.additional[].hosts[]`                                | Hosts for additional TLS config                                                             |                                                          |
 
 ### Home worker
 

--- a/charts/grist/templates/doc_wk_deployment.yaml
+++ b/charts/grist/templates/doc_wk_deployment.yaml
@@ -26,6 +26,9 @@ spec:
       labels:
         {{- include "grist.common.selectorLabels" (list . $component) | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       {{- with .Values.docWorker.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/grist/templates/home_wk_deploy.yaml
+++ b/charts/grist/templates/home_wk_deploy.yaml
@@ -26,6 +26,9 @@ spec:
       labels:
         {{- include "grist.common.selectorLabels" (list . $component) | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       {{- if $.Values.image.credentials }}
       imagePullSecrets:
         - name: {{ include "grist.secret.dockerconfigjson.name" (dict "fullname" (include "grist.fullname" .) "imageCredentials" $.Values.image.credentials) }}

--- a/charts/grist/templates/lb_deploy.yaml
+++ b/charts/grist/templates/lb_deploy.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         {{- include "grist.common.selectorLabels" (list . $component) | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       {{- if $.Values.image.credentials }}
       imagePullSecrets:
         - name: {{ include "grist.secret.dockerconfigjson.name" (dict "fullname" (include "grist.fullname" .) "imageCredentials" $.Values.image.credentials) }}

--- a/charts/grist/templates/serviceaccount.yaml
+++ b/charts/grist/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.enabled -}}
+{{- $fullName := include "grist.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    {{- include "grist.common.labels" (list . $component) | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- if $.Values.image.credentials }}
+imagePullSecrets:
+  - name: {{ include "grist.secret.dockerconfigjson.name" (dict "fullname" (include "grist.fullname" .) "imageCredentials" $.Values.image.credentials) }}
+{{- end }}
+{{- end }}

--- a/charts/grist/values.yaml
+++ b/charts/grist/values.yaml
@@ -31,6 +31,20 @@ fullnameOverride: ""
 ## @extra mountFiles[].content File content encoded in base64
 mountFiles: []
 
+## @param serviceAccount.enabled Whether to enable the service account or not
+## @param serviceAccount.name Name to use for the service account
+## @param serviceAccount.imagePullSecrets Image pull secrets for the service account
+## @param serviceAccount.annotations Annotations for the service account
+## @param serviceAccount.labels Labels for the service account
+## @param serviceAccount.automountServiceAccountToken Set this toggle to false to opt out of automounting API credentials for the service account
+serviceAccount:
+  enabled: false
+  name: grist
+  imagePullSecrets: []
+  annotations: {}
+  labels: {}
+  automountServiceAccountToken: true
+
 ## @param ingress.enabled whether to enable the Ingress or not
 ## @param ingress.className IngressClass to use for the Ingress
 ## @param ingress.host Host for the Ingress


### PR DESCRIPTION
Adds the posibility to use a service account in the deployment