### PR TITLE
Make loadBalancer component optional, enabled by default.

### DIFF
--- a/charts/grist/templates/ingress.yaml
+++ b/charts/grist/templates/ingress.yaml
@@ -64,6 +64,7 @@ spec:
               serviceName: {{ include "grist.home.fullname" . }}
               servicePort: {{ $svcPort }}
             {{- end }}
+          {{- if $.Values.loadBalancer.enabled }}
           - path: /dw
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
@@ -78,6 +79,7 @@ spec:
               serviceName: {{ include "grist.lb.fullname" . }}
               servicePort: {{ $svcPort }}
             {{- end }}
+          {{- end }}
     {{- end }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
@@ -97,6 +99,7 @@ spec:
               serviceName: {{ include "grist.home.fullname" $ }}
               servicePort: {{ $svcPort }}
             {{- end }}
+          {{- if $.Values.loadBalancer.enabled }}
           - path: /dw
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
@@ -111,6 +114,7 @@ spec:
               serviceName: {{ include "grist.lb.fullname" $ }}
               servicePort: {{ $svcPort }}
             {{- end }}
+          {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}

--- a/charts/grist/templates/lb_cm.yaml
+++ b/charts/grist/templates/lb_cm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loadBalancer.enabled }}
 {{- $svcName := include "grist.doc.fullname" . -}}
 {{- $component := "lb" -}}
 apiVersion: v1
@@ -51,3 +52,4 @@ data:
         proxy_set_header Connection "upgrade";
       }
     }
+{{- end }}

--- a/charts/grist/templates/lb_deploy.yaml
+++ b/charts/grist/templates/lb_deploy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loadBalancer.enabled }}
 {{- $envVars := include "grist.env.transformDict" .Values.loadBalancer.envVars -}}
 {{- $fullName := include "grist.lb.fullname" . -}}
 {{- $component := "lb" -}}
@@ -101,3 +102,4 @@ spec:
         {{- with .Values.loadBalancer.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+{{- end }}

--- a/charts/grist/templates/lb_svc.yaml
+++ b/charts/grist/templates/lb_svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loadBalancer.enabled }}
 {{- $component := "lb" -}}
 apiVersion: v1
 kind: Service
@@ -16,3 +17,4 @@ spec:
       name: http
   selector:
     {{- include "grist.common.selectorLabels" (list . $component) | nindent 4 }}
+{{- end }}

--- a/charts/grist/values.yaml
+++ b/charts/grist/values.yaml
@@ -302,6 +302,9 @@ docWorker:
 ## @section Grist doc worker load balancer
 
 loadBalancer:
+  ## @param loadBalancer.enabled Wether or not to enable loadBalancer component
+  enabled: true
+
   ## @param loadBalancer.image.repository Repository to use to pull the load balancer container image
   ## @param loadBalancer.image.tag Load balancer container tag
   ## @param loadBalancer.image.pullPolicy Load balancer container image pull policy


### PR DESCRIPTION
Hi,

I recently tried to install grist as a tiny instance for my association. The loadBalancer component throws me a 413 http error when I try to import a 3.6mb .grist file, despite my client_max_body_size like configuration. I'm currently using traefik as ingress controller. 

I also had 404 errors. Instead of tryin to debug these issues, i wonder myself what was the purpose of thoses loadbalancers ? I do not get that. 

Maybe in case of huge deployment, as is probably the one at dirnum.

My PR concerns a proposal to disable the LB if those are not required. Probably more fit for tiny organizations. 
I'd be happy to discuss it further with you.   