### PR TITLE
fix(grist): use correct fullname helper for doc worker PVC

### DIFF
--- a/charts/grist/templates/doc_wk_pvc.yaml
+++ b/charts/grist/templates/doc_wk_pvc.yaml
@@ -4,7 +4,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ include "grist.fullname" $ }}-{{ $name }}"
+  name: "{{ include "grist.doc.fullname" $ }}-{{ $name }}"
   labels:
     {{- include "grist.labels" $ | nindent 4 }}
   {{- if $volume.annotations }}


### PR DESCRIPTION
## Summary

- Fix PVC name mismatch for doc worker persistence volumes
- `doc_wk_pvc.yaml` used `grist.fullname` to generate the PVC name, while `doc_wk_deployment.yaml` references it via `grist.doc.fullname` (which appends `-doc-wk`)
- This causes the doc worker pod to fail with `persistentvolumeclaim not found` because the created PVC and the referenced claimName don't match

## Changes

One-line fix in `charts/grist/templates/doc_wk_pvc.yaml`:

```diff
-  name: "{{ include "grist.fullname" $ }}-{{ $name }}"
+  name: "{{ include "grist.doc.fullname" $ }}-{{ $name }}"
```

## Verification

```
# Before fix:
PVC name:    test-release-grist-persist
claimName:   test-release-grist-doc-wk-persist  ← mismatch!

# After fix:
PVC name:    test-release-grist-doc-wk-persist
claimName:   test-release-grist-doc-wk-persist  ← match ✓
```